### PR TITLE
Use global GHC, bump GHC version

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -21,8 +21,9 @@ jobs:
         enable-stack: true
         stack-version: "latest"
         cabal-version: "latest"
-        ghc-version: "8.8.3"
-        stack-setup-ghc: true
+        ghc-version: "8.8.4"
+        stack-setup-ghc: false
+        stack-no-global: true
     - name: Cache
       uses: actions/cache@v1
       env:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -23,7 +23,6 @@ jobs:
         cabal-version: "latest"
         ghc-version: "8.8.4"
         stack-setup-ghc: false
-        stack-no-global: true
     - name: Cache
       uses: actions/cache@v1
       env:


### PR DESCRIPTION
* Use the system GHC instead of downloading it and building it
* Update the GHC version to match the current resolver
