### PR TITLE
Add compiler version to the build matrix

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,32 +1,44 @@
 name: Haskell CI
 
+# Trigger the workflow on push or pull request, but only for the main branch
 on:
-  push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
+  push:
+    branches: [main]
 
 jobs:
-  build:
+  stack:
+    name: ${{ matrix.os }} / ghc-${{ matrix.ghc }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-          - macOS-latest
+        ghc: ["8.8.4", "latest"]
+        os: ["ubuntu-latest", "macOS-latest", "windows-latest"]
+
     steps:
     - uses: actions/checkout@v2
+      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/main'
+
     - uses: haskell/actions/setup@v1
+      name: Setup Haskell Stack
       with:
+        ghc-version: ${{ matrix.ghc }}
         enable-stack: true
-        stack-version: "latest"
-        cabal-version: "latest"
-        ghc-version: "8.8.4"
-        stack-setup-ghc: true
+
     - uses: actions/cache@v2.1.3
       name: Cache ~/.stack
       with:
         path: ~/.stack
-        key: ${{ runner.os }}-${{ matrix.ghc }}-stack
-    - name: Check build
-      run: stack build --fast --system-ghc
+        key: ${{ runner.os }}-${{ matrix.ghc }}-stack-v2
+
+    - name: Install dependencies
+      run: |
+        stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks --only-dependencies
+
+    - name: Build
+      run: |
+        stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks
+
+    - name: Test
+      run: |
+        stack test --system-ghc


### PR DESCRIPTION
Add the compiler version to the build matrix so we can start testing more compiler versions and provide the keys for the cache